### PR TITLE
Update Django to 3.0.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ https://www.cwls.org/products/
 - Unit testing with data fixtures.
 - Test coverage reporting.
 
-It has been tested with Django 2.2.10.
+It has been tested with Django versions 3.0.6 and 2.2.10.
 
 The default database is sqlite.
 
@@ -167,10 +167,10 @@ DEPENDENCIES
 
 | Component | Version |
 |-----------|---------|
-| coverage              | 4.5.4  | 
-| Django                | 2.2.10 | 
-| Django-Rest-Framework | 3.10.3 | 
-| Pytz                  | 2019.2 | 
+| coverage              | 5.1  | 
+| Django                | 3.0.6 | 
+| Django-Rest-Framework | 3.11.0 | 
+| Pytz                  | 2020.1 | 
 | Sqlite3               | |
 
 Django and Django-Rest-Framework can be installed with

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,8 @@
-coverage==4.5.4
-Django==2.2.10
-djangorestframework==3.10.3
-pytz==2019.2
-sqlparse==0.3.0
+asgiref==3.2.7
+coverage==5.1
+Django==3.0.6
+djangorestframework==3.11.0
+pytz==2020.1
+readline==6.2.4.1
+six==1.15.0
+sqlparse==0.3.1


### PR DESCRIPTION
- Update Django to 3.0.6 and DjangoRestFramework to 3.11.0.
- Verify that the test suite passes and the basic functionality runs as
  before.