### PR TITLE
Fix ValueError on uploading sample_2.0.las

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,18 +3,18 @@ NAME
 
 LAS Util - LAS web tools in Python/Django
 
-TABLE OF CONTENTS
+TABLE-OF-CONTENTS
 -----------------
-- [DESCRIPTION](#DESCRIPTION)
-- [SYNOPSIS](#SYNOPSIS)
-- [REST-API](#REST-API)
-- [PROJECT-ROADMAP](#PROJECT-ROADMAP)
-- [DEPENDENCIES](#DEPENDENCIES)
-- [BUGS](#BUGS)
-- [COPYRIGHT](#COPYRIGHT)
+- [DESCRIPTION](#description)
+- [SYNOPSIS](#synopsis)
+- [REST-API](#rest-api)
+- [PROJECT-ROADMAP](#project-roadmap)
+- [DEPENDENCIES](#dependencies)
+- [BUGS](#bugs)
+- [COPYRIGHT](#copyright)
 
 
-DESCRIPTION
+[DESCRIPTION](#name)
 -----------
 Caution: This is beta software!
 
@@ -28,10 +28,10 @@ the Canadian Well Logging Society at
 https://www.cwls.org/products/
 
 `LAS-Util-Django` current functionality:
-- Upload a LAS file that includes the VERSION and optionally: WELL, CURVE
-  and PARAMETER sections.
+- Upload a LAS file that includes the VERSION and optionally: WELL, CURVE,
+  PARAMETER and optional OTHER sections.
 - Parse the VERSION section.
-- Parse the WELL, CURVE and PARAMETER sections if they exist.
+- Parse the WELL, CURVE, PARAMETER and OTHER sections if they exist.
 - Store the parsed data in a SQLite database.
 - Display a list of processed files with links to their details.
 - Display detailed data in a table format.
@@ -40,12 +40,12 @@ https://www.cwls.org/products/
 - Unit testing with data fixtures.
 - Test coverage reporting.
 
-It has been tested with Django versions 3.0.7 and 2.2.10.
+It has been tested with Django versions 3.0.7.
 
 The default database is sqlite.
 
 
-SYNOPSIS
+[SYNOPSIS](#name)
 ---------
 
   ```bash
@@ -122,7 +122,7 @@ Select the 'Display-Files' menu item. The uploaded file will have the most recen
   http://127.0.0.1:8000/list/
 
 
-REST-API
+[REST-API](#name)
 --------
 
 To upload a LAS doc use a post command:
@@ -167,7 +167,7 @@ curl http://127.0.0.1:8000/api/detail/las_file-2019-08-29-21-41-42
 ```
 
 
-PROJECT-ROADMAP
+[PROJECT-ROADMAP](#name)
 ----------------
 
 `LAS-Util-Django`'s project road-map is managed in github milestones at: 
@@ -183,7 +183,7 @@ To request and discuss a potiential feature or report a bug create an issue at:
      
 
 
-DEPENDENCIES
+[DEPENDENCIES](#name)
 ------------
 
 | Component | Version |
@@ -200,14 +200,14 @@ cd las-util-django/
 pip install -r requirements.txt
 ```
 
-BUGS
+[BUGS](#name)
 ----
 
 - Functionality is basic.
 - Report bugs by creating an issue at:    
   https://github.com/dcslagel/las-util-django/issues
 
-COPYRIGHT
+[COPYRIGHT](#name)
 ---------
 
 Copyright (c) 2019 DC Slagel and contributors

--- a/src/las_util/cntrl.py
+++ b/src/las_util/cntrl.py
@@ -41,24 +41,18 @@ def parse(las_file):
         # Skip comment lines.
         elif line[0] == '#':
             continue
-        
-        """
-        Version section delimiters
-        1. the first dot: '.'
-        2. the first space after the dot: ' '
-        3. the last colon that is not part of a time string.
-           currently we are using a pattern of a colon without
-           2 numbers or 'mm' after it. Examples to ignore: '4:05' and 'H:mm'.
-        """
-        non_time_colon = r":(?!\d{2}|mm)"
-        entry.name, remaining_string = line.split('.', maxsplit=1)
-        entry.unit, remaining_string = remaining_string.split(' ', maxsplit=1)
-        entry.value, entry.note = re.split(non_time_colon, remaining_string)
 
-        entry.name = entry.name.strip()
-        entry.value = entry.value.strip()
-        entry.note = entry.note.strip()
-        entry.section = section
+        # LAS standard option 'OTHER' section
+        if section[1] == 'O': 
+            entry.value = line
+            entry.section = section
+        # The rest of the standard metadata sections
+        elif section[1] in ['V', 'W', 'C', 'P']:
+            entry = parse_formatted_section_line(section, line, entry)
+        # the data section and non-standard sections
+        else:
+            # print("Non-Metadata-Section: [{}]: [{}]".format(section[0:2], line))
+            continue
 
         # Write entry to db
         entry.save()
@@ -68,3 +62,25 @@ def parse(las_file):
         entry.filename = entry_filename
 
     return entry_filename
+
+
+def parse_formatted_section_line(section, line, entry):
+    """
+    Version section delimiters
+    1. the first dot: '.'
+    2. the first space after the dot: ' '
+    3. the last colon that is not part of a time string.
+       currently we are using a pattern of a colon without
+       2 numbers or 'mm' after it. Examples to ignore: '4:05' and 'H:mm'.
+    """
+    non_time_colon = r":(?!\d{2}|mm)"
+    entry.name, remaining_string = line.split('.', maxsplit=1)
+    entry.unit, remaining_string = remaining_string.split(' ', maxsplit=1)
+    entry.value, entry.note = re.split(non_time_colon, remaining_string)
+
+    entry.name = entry.name.strip()
+    entry.value = entry.value.strip()
+    entry.note = entry.note.strip()
+    entry.section = section
+
+    return entry


### PR DESCRIPTION
Resolves #5  Bug: ValueError on uploading sample_2.0.las

We need to skip the special metadata parsing for the optional ~OTHER section and for the ~ASCII (data) section.  

- We are ignoring the ~ASCII data section for this release. It will be addressed in an upcoming release.  
- Customer defined sections are not handled yet so this fix doesn't address them.

All current tests pass.

