### PR TITLE
Add initial metadata-parsing tests

### DIFF
--- a/src/las_util/tests/test_cntrl.py
+++ b/src/las_util/tests/test_cntrl.py
@@ -1,0 +1,61 @@
+import sys
+
+# django's database is not needed so we use unittest.TestCase
+# from django.test import TestCase
+from unittest import TestCase
+
+
+import las_util.cntrl as cntrl
+
+
+# Create your tests here.
+class ParseRecordTests(TestCase):
+
+    """
+    @classmethod
+    def setUpTestData(self):
+        '''print("setUpTestData: Run once to set up data for all ModelTests")'''
+        pass
+
+    def setUp(self):
+        '''print("setUp: Run once for every test method")'''
+        pass
+    """
+
+    def test_parse_version_record(self):
+        entry = cntrl.SectionInfo()
+        line = "VERS.               2.0 :   CWLS LOG ASCII STANDARD -VERSION 2.0"
+        entry = cntrl.parse_formatted_section_line("V", line, entry)
+        self.assertEqual(entry.name, "VERS")
+        self.assertEqual(entry.unit, "")
+        self.assertEqual(entry.value, "2.0")
+        self.assertEqual(entry.note, "CWLS LOG ASCII STANDARD -VERSION 2.0")
+
+
+    def test_parse_well_record(self):
+        entry = cntrl.SectionInfo()
+        line = "STRT    .M              1670.0000                :START DEPTH"
+        entry = cntrl.parse_formatted_section_line("W", line, entry)
+        self.assertEqual(entry.name, "STRT")
+        self.assertEqual(entry.unit, "M")
+        self.assertEqual(entry.value, "1670.0000")
+        self.assertEqual(entry.note, "START DEPTH")
+
+    def test_parse_curve_record(self):
+        entry = cntrl.SectionInfo()
+        line = "DEPT   .M                                       :  1  DEPTH"
+        entry = cntrl.parse_formatted_section_line("C", line, entry)
+        self.assertEqual(entry.name, "DEPT")
+        self.assertEqual(entry.unit, "M")
+        self.assertEqual(entry.value, "")
+        self.assertEqual(entry.note, "1  DEPTH")
+
+    def test_parse_param_record(self):
+        entry = cntrl.SectionInfo()
+        line = "MUD    .               GEL CHEM        :   MUD TYPE"
+        entry = cntrl.parse_formatted_section_line("", line, entry)
+        self.assertEqual(entry.name, "MUD")
+        self.assertEqual(entry.unit, "")
+        self.assertEqual(entry.value, "GEL CHEM")
+        self.assertEqual(entry.note, "MUD TYPE")
+

--- a/src/las_util/tests/test_cntrl_db.py
+++ b/src/las_util/tests/test_cntrl_db.py
@@ -1,0 +1,46 @@
+import sys
+import os 
+
+from django.test import TestCase
+# from unittest import TestCase
+
+
+import las_util.cntrl as cntrl
+
+
+# Create your tests here.
+class ParseRecordTests(TestCase):
+
+    """
+    @classmethod
+    def setUpTestData(self):
+        '''print("setUpTestData: Run once to set up data for all ModelTests")'''
+        pass
+
+    def setUp(self):
+        '''print("setUp: Run once for every test method")'''
+        pass
+    """
+
+    def test_parse_record(self):
+        dir_path = os.path.dirname(os.path.realpath(__file__))
+        las_path = dir_path + "/../example_data/sample_2.0.las"
+        las_file = open(las_path, "+rb")
+        entry_filename = cntrl.parse(las_file)
+        self.assertEqual(entry_filename[0:8], "las_file")
+        self.assertTrue(entry_filename.endswith('.las'))
+        self.assertEqual(cntrl.SectionInfo.objects.count(), 32)
+
+        pList = cntrl.SectionInfo.objects.all()
+
+        # Check expected number of records
+        self.assertEqual(pList.distinct().count(), 32)
+        self.assertEqual(pList.filter(section = "~VERSION INFORMATION").count(), 2)
+        self.assertEqual(pList.filter(section = "~WELL INFORMATION").count(), 12)
+        self.assertEqual(pList.filter(section = "~CURVE INFORMATION").count(), 8)
+        self.assertEqual(pList.filter(section = "~PARAM INFORMATION").count(), 0)
+        self.assertEqual(pList.filter(section = "~OTHER").count(), 2)
+        self.assertEqual(pList.filter(section = "").count(), 0)
+
+        # Check specific data
+        self.assertEqual(pList.get(section = "~VERSION INFORMATION", name = "VERS").value, '2.0')


### PR DESCRIPTION
Resolves #14  Testing: Add tests for Well data parsed from a las file.

This pull request adds tests for parsing Log Ascii Standard line-based records.
The parsing functions are in cntrl.py:
-  parse()
- parse_formatted_section_line(section, line, entry)

All tests pass